### PR TITLE
Created minimally-functional version of game loop with working terminal window

### DIFF
--- a/README
+++ b/README
@@ -20,3 +20,63 @@ Colors for messages and glyphs may be specified in one of three ways:
 	- as a comma-separated RGB string, R,G,B or A,R,G,B
 	128,255,255,0 = brown
 
+INPUT HANDLING
+(this info summarized from http://foo.wyrd.name/en:bearlibterminal:reference:input )
+In addition to the terminal output, BearLibTerminal will handle the keyboard
+input and associated events.
+HANDLING INPUT
+int terminal_has_input();
+	Returns a boolean value indicating whether input is waiting to be processed.
+int terminal_read();
+	Returns the next event from the input queue. If there are no more events in the queue, _read will block (wait) for an event to occur.
+int terminal_peek();
+	As with _read(), but does not remove the event from the queue or block if the queue is empty (returns 0 instead).
+
+CHECKING STATE
+int terminal_state(int slot);
+	Returns the current value of the state slot.
+int terminal_check(int slot);
+	Returns a boolean value that corresponds to the value of the state slot.
+
+Shortlist of States and Events:
+-------------------------------
+Keyboard inputs:
+EVENT: TRUE if the corresponding key was pressed
+STATE: current state of the key (see website info on input queue for details)
+
+TK_A ... TK_Z
+TK_0 ... TK_9
+TK_F1 ... TK_F12
+TK_SPACE
+TK_MINUS
+TK_EQUALS
+TK_RETURN
+TK_LBRACKET
+TK_RBRACKET
+TK_BACKSLASH
+TK_SEMICOLON
+TK_BACKSPACE
+(etc)
+
+Mouse inputs:
+(As of this writing (01/24/2020), mouse input needs to be enabled via the BLT configuration string before it can be detected.)
+EVENT: TRUE if corresponding button was pressed
+STATE: current state of the button
+TK_MOUSE_LEFT
+TK_MOUSE_RIGHT
+TK_MOUSE MIDDLE
+TK_MOUSE_X1
+TK_MOUSE_X2
+TK_MOUSE_MOVE evaluates TRUE if the mouse cursor has changed position by at least one cell
+TK_MOUSE_X	x-coordinate of cursor in terms of terminal cells
+TK_MOUSE_Y	y-coordinate of cursor in terms of terminal cells
+TK_MOUSE_PIXEL_X x-coordinate of mouse cursor in pixels
+TK_MOUSE_PIXEL_Y y-coordinate of mouse cursor in pixel
+TK_MOUSE_CLICKS	Number of fast consecutive clicks (ie single vs double-click)
+
+Terminal properties:
+TK_WIDTH	Width of terminal in cells
+TK_HEIGHT	Height of terminal in cells
+TK_EVENT	Code of the last dequeued input event (ie last keypress)
+
+

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -59,12 +59,25 @@ screenHeight(50)
 
 void GameEngine::loop()
 {
-	// Fetch player action
-	// Perform action
-	// Write result
-//	auto player_pos = player.getPos();
-	gui.update();
-	gui.render();
+	// BLT display explicitly requires an initial call to _refresh() prior to
+	// displaying anything onscreen
+	terminal_refresh();
+	// TK_CLOSE == true when the terminal window is closed
+	while (terminal_peek() != TK_CLOSE) { // _peek does not block if false (unlike _read)
+		// Fetch player action
+		if (terminal_has_input()) { // Is there control input waiting?
+			// Perform action
+			// Parse the command input by reading it from terminal_
+			int inputKey = terminal_read();
+			if (inputKey == TK_Q) {
+				// Press Q to quit
+				break;
+			}
+		}
+		// Write result
+		gui.update();
+		gui.render();
+	};
 }
 
 bool GameEngine::initialize(const std::string& configFile)

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -119,13 +119,12 @@ void GameGUI::update() {
 }
 void GameGUI::render() {
 	// draws the interface onto the screen
-//	testBLT();
+	testBLT();
 	terminal_refresh(); // Tell BLT to go ahead and update the display
 }
 void GameGUI::testBLT() {
 	// Debugging function to assist with checking BearLibTerminal functions
 	// try printing something to the screen and wait until the window is closed
-	terminal_print(1, 1, "Hello, world!");
+	terminal_print(1, 1, "Press Q or Alt+F4 to exit.");
 	terminal_refresh();
-	while (terminal_read() != TK_CLOSE);
 }


### PR DESCRIPTION
I wrote a simple example of a game window loop while I was debugging my GUI logic. Please do modify it to your needs; as it stands now, it's just enough to show some output and wait for the player to quit. If you run into problems dealing with BearLibTerminal, don't hesitate to let me know.

The README has more info, and the changes to gui.cpp are merely to enable a debugging function that will display the "Press Q to quit" message.

(From the commit message:)
This is a very simple game loop that will remain open safely until the player closes the game window, whether by hitting Q or closing the terminal window.

In addition, the README has been updated with information on how to get state and input information from BearLibTerminal, as well as a list of events and keys that BLT can observe. There is much more comprehensive information available at
   [http://foo.wyrd.name/en:bearlibterminal:reference:input]

 On branch gameLoopPrototype
 Changes to be committed:
	modified:   README
	modified:   src/engine.cpp
	modified:   src/gui.cpp